### PR TITLE
License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Astro Breaker
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE. 

--- a/README.md
+++ b/README.md
@@ -161,3 +161,14 @@ credits for blop1 sound effects: https://kronbits.itch.io/freesfx?download#googl
 ## Credits
 Sound Effects:
 - Block breaking sounds: [Kronbits Free SFX Pack](https://kronbits.itch.io/freesfx)
+
+## Licensing
+
+This project uses a dual licensing approach:
+
+- **Main Code**: Licensed under the MIT License - see the [LICENSE](./LICENSE) file
+- **Assets Directory**: Assets in the `/assets` directory are licensed under the HYTOPIA LIMITED USE LICENSE - see [assets/LICENSE.md](./assets/LICENSE.md)
+
+The MIT License allows you to freely use, modify, and distribute the original code, while the HYTOPIA assets have more restricted usage terms.
+
+Astro Breaker © 2025

--- a/README.md
+++ b/README.md
@@ -173,6 +173,6 @@ The MIT License allows you to freely use, modify, and distribute the original co
 
 ### Third-Party Assets
 
-- **Bomb Model**: The projectile bomb model (`assets/models/projectiles/bomb.gltf`) is licensed under the **Fab End User License Agreement**. This is a separate license from Epic Games Marketplace and has its own terms of use. This model may not be redistributed separately from this project.
+- **Bomb Model**: The projectile bomb model (`assets/models/projectiles/bomb.gltf`) is licensed under the **Fab End User License Agreement**. This is a separate license from Epic Games Marketplace and has its own terms of use. This model may not be redistributed separately from this project. **Important:** If you fork this project, you will need to purchase your own license for this asset or replace it with your own model.
 
 Astro Breaker © 2025

--- a/README.md
+++ b/README.md
@@ -171,4 +171,8 @@ This project uses a dual licensing approach:
 
 The MIT License allows you to freely use, modify, and distribute the original code, while the HYTOPIA assets have more restricted usage terms.
 
+### Third-Party Assets
+
+- **Bomb Model**: The projectile bomb model (`assets/models/projectiles/bomb.gltf`) is licensed under the **Fab End User License Agreement**. This is a separate license from Epic Games Marketplace and has its own terms of use. This model may not be redistributed separately from this project.
+
 Astro Breaker © 2025

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "block-breaking-game",
   "version": "1.0.0",
   "description": "A game where you throw things at blocks to break them",
+  "license": "MIT",
   "scripts": {
     "test": "jest"
   },


### PR DESCRIPTION
Changes:
Added MIT License (2025 Astro Breaker) for all original code
Updated package.json with "license": "MIT" field
Enhanced README.md with licensing sections:
Dual license structure (MIT for code, HYTOPIA LIMITED USE for assets)
Special Fab license notation for the bomb projectile model
Copyright notice (Astro Breaker © 2025)